### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -86,6 +86,9 @@ export function setDeep(
 	// Get the deepmost item
 	for (let i = 0, n = keys.length - 1; i < n; ++i) {
 		const key = keys[i]
+		if (isPrototypePolluted(key)) {
+			continue
+		}
 		const tmp = getDeep(subject, key)
 		if (tmp) {
 			subject = tmp
@@ -114,4 +117,9 @@ export function setDeep(
 
 	// Return
 	return result
+}
+
+/** Blacklist certain keys to prevent Prototype Pollution */
+function isPrototypePolluted(key: any): boolean {
+	return ['__proto__', 'constructor', 'prototype'].includes(key)
 }

--- a/source/test.ts
+++ b/source/test.ts
@@ -88,5 +88,10 @@ kava.suite('getsetdeep', function (suite, test) {
 			equal(setDeep(src, 'a.z.x.y', 'yay'), 'yay')
 			equal(getDeep(src, 'a.z.x.y'), 'yay')
 		})
+
+		test('should not set object prototype', function () {
+			equal(setDeep(src, '__proto__.polluted', true), true)
+			equal(getDeep(src, '__proto__.polluted'), undefined)
+		})
 	})
 })


### PR DESCRIPTION
### :bar_chart: Metadata \*

`getsetdeep` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-getsetdeep

### :gear: Description \*

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description \*

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) \*

1. Create the following PoC file:

```JavaScript
// poc.js
const getsetdeep = require('getsetdeep')
console.log('Before : ' + {}.polluted)
getsetdeep.setDeep({}, '__proto__.polluted', 'Yes! Its Polluted')
console.log('After : ' + {}.polluted)
```

2. Execute the following commands in terminal:

```bash
npm i getsetdeep # Install affected module
node poc.js #  Run the PoC
```

3. Check the Output:

```
Before : undefined
After : Yes! Its Polluted
```

### :fire: Proof of Fix (PoF) \*

*I've added unit tests for Prototype Pollution*

![image](https://user-images.githubusercontent.com/43996156/105156732-3aec7700-5b32-11eb-9443-1ff3ae2d707f.png)

### +1 User Acceptance Testing (UAT)

-   I've executed unit tests.
-   After fix the functionality is unaffected.
