### PR TITLE
Disallow prototype path override - checking magic attributes

### DIFF
--- a/source/test.ts
+++ b/source/test.ts
@@ -2,7 +2,7 @@
 'use strict'
 
 // Import
-import { equal } from 'assert-helpers'
+import { equal, expectThrowViaFunction } from 'assert-helpers'
 import kava from 'kava'
 import { getDeep, setDeep } from './index.js'
 import Backbone from 'backbone'
@@ -87,6 +87,21 @@ kava.suite('getsetdeep', function (suite, test) {
 		test('set nested undefined value', function () {
 			equal(setDeep(src, 'a.z.x.y', 'yay'), 'yay')
 			equal(getDeep(src, 'a.z.x.y'), 'yay')
-		})
+    })
+    
+    test('set throws when unsafe path encountered', function () {
+      const getErrorMsg = function(path: string[]) {
+        return "Unsafe path encountered: " + path;
+      }
+      const raiseError = function(obj: object, keys: string, value: string) {
+        return function() {
+          setDeep(obj, keys, value)
+          throw new Error('Test failed')
+        }
+      }
+      expectThrowViaFunction(getErrorMsg(['__proto__', 'polluted']), raiseError(src, '__proto__.polluted', 'Polluted'))
+      expectThrowViaFunction(getErrorMsg(['constructor', 'prototype', 'polluted']), raiseError(src, 'constructor.prototype.polluted', 'Polluted'))
+      expectThrowViaFunction(getErrorMsg(['prototype', 'polluted']), raiseError(Object, 'prototype.polluted', 'Polluted'))
+    })
 	})
 })


### PR DESCRIPTION
### 📊 Metadata *

`getsetdeep` is vulnerable to Prototype Pollution. This package fails to restrict access to prototypes of objects, allowing for modification of prototype behavior using a `__proto__`payload, which may result in Sensitive Information Disclosure/Denial of Service(DoS)/Remote Code Execution.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-getsetdeep/

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes. The bug is fixed by validating the input strArray to check for prototypes. It is implemented by a simple validation to check for prototype keywords (proto, constructor and prototype), where if it exists, the function throws exception, thus fixing the Prototype Pollution Vulnerability.

### 🐛 Proof of Concept (PoC) *


1. Create the following PoC file:

```
// poc.js
var getsetdeep = require("getsetdeep")
const obj = {}
console.log("Before : " + {}.polluted);
getsetdeep.setDeep(obj, '__proto__.polluted', 'Yes! Its Polluted');
console.log("After : " + {}.polluted);
```

2. Execute the following commands in another terminal:

```
npm i getsetdeep # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:

```
Before : undefined
After : Yes! It's Polluted
```

### 🔥 Proof of Fix (PoF) *

Before:
![image](https://user-images.githubusercontent.com/64132745/106886148-91001380-6709-11eb-8dfd-265a3b8d7b16.png)

After:
![image](https://user-images.githubusercontent.com/64132745/106886240-ab39f180-6709-11eb-894b-699b52b39919.png)


### 👍 User Acceptance Testing (UAT)

After the fix, functionality is unaffected.

![image](https://user-images.githubusercontent.com/64132745/106892224-c446a080-6711-11eb-80b1-01c881faa5ae.png)

### 🔗 Relates to...

https://github.com/418sec/huntr/pull/1824
